### PR TITLE
Added more QOL changes:

### DIFF
--- a/FFXIVConductor/MainWindow.xaml.cs
+++ b/FFXIVConductor/MainWindow.xaml.cs
@@ -45,7 +45,7 @@ namespace FFXIVConductor
                 }
                 catch (IOException)
                 {
-                    MessageBox.Show("Could not access game data. Please close FFXIV and run program as admin", "Error", MessageBoxButton.OK,
+                    MessageBox.Show("Could not access game data. Please close FFXIV and run FFXIVConductor as admin", "Error", MessageBoxButton.OK,
                         MessageBoxImage.Error);
                     return;
                 }


### PR DESCRIPTION
-If there are existing empty tracks in the midi, adds 1 dummy note to them
-If there are more than 7 tracks, ignore all but the first 7 tracks.
-If the first track in the midi has only 1 note (indicating empty or dummy track), sort the tracks in descending order based on the count of notes in them (i.e, track with most notes comes first). This all but guarantees that the track user wanted to actually transpose ends up as the first track while minimizing chance of scrambling order by mistake.
-Orders notes by their time values, and cuts the length of any notes that overlap with the next note in the sequence to ensure wind instruments do not break.